### PR TITLE
Ajout Laser, fonction shoot, destruction obstacle, tests

### DIFF
--- a/src/main/java/com/esiea/tp4A/domain/LaserBeamImpl.java
+++ b/src/main/java/com/esiea/tp4A/domain/LaserBeamImpl.java
@@ -1,0 +1,38 @@
+package com.esiea.tp4A.domain;
+
+public class LaserBeamImpl {
+
+    private Position currentPosition;
+    private Direction currentDirection;
+    private boolean destroyed;
+
+    LaserBeamImpl(int x, int y, Direction direction) {
+        currentPosition = Position.of(x, y, direction);
+        destroyed = false;
+    }
+
+    public Position getCurrentPosition(){
+        return currentPosition;
+    }
+
+    public Position move (PlanetMapImpl planetMap){
+        if(!destroyed){
+            if(currentDirection == Direction.SOUTH) currentPosition = Position.of(currentPosition.getX(), currentPosition.getY()-1, currentDirection);
+            if(currentDirection == Direction.WEST) currentPosition = Position.of(currentPosition.getX()-1, currentPosition.getY(), currentDirection);
+            if(currentDirection == Direction.NORTH) currentPosition = Position.of(currentPosition.getX(), currentPosition.getY()+1, currentDirection);
+            if(currentDirection == Direction.EAST) currentPosition = Position.of(currentPosition.getX()+1, currentPosition.getY(), currentDirection);
+        }
+        obstacleCollisionCheck(planetMap);
+        if(destroyed){ return null; }
+        else{ return currentPosition;}
+    }
+
+    //si le laser rencontre un obstacle, ces deux éléments sont détruits
+    public void obstacleCollisionCheck(PlanetMapImpl planetMap){
+        if(planetMap.getInfo(currentPosition.getX(), currentPosition.getY())==1){
+            planetMap.setMapSquare(currentPosition.getX(), currentPosition.getY(), 0);
+            destroyed = true;
+        }
+    }
+
+}

--- a/src/main/java/com/esiea/tp4A/domain/MarsRoverImpl.java
+++ b/src/main/java/com/esiea/tp4A/domain/MarsRoverImpl.java
@@ -80,4 +80,15 @@ public class MarsRoverImpl implements MarsRover {
         return false;
     }
 
+    //génère un nouveau missile dans la direction du Rover
+    public LaserBeamImpl Shoot(PlanetMapImpl planetMap){
+        int laserBeamX = 0, laserBeamY = 0;
+        if(currentPosition.getDirection() == Direction.SOUTH){ laserBeamX = currentPosition.getX(); laserBeamY = currentPosition.getY()-1;}
+        if(currentPosition.getDirection() == Direction.NORTH){ laserBeamX = currentPosition.getX(); laserBeamY = currentPosition.getY()+1;}
+        if(currentPosition.getDirection() == Direction.WEST){ laserBeamX = currentPosition.getX()-1; laserBeamY = currentPosition.getY();}
+        if(currentPosition.getDirection() == Direction.EAST){ laserBeamX = currentPosition.getX()+1; laserBeamY = currentPosition.getY();}
+        LaserBeamImpl laserBeam = new LaserBeamImpl(laserBeamX, laserBeamY, currentPosition.getDirection());
+        return laserBeam;
+    }
+
 }

--- a/src/main/java/com/esiea/tp4A/domain/PlanetMapImpl.java
+++ b/src/main/java/com/esiea/tp4A/domain/PlanetMapImpl.java
@@ -30,6 +30,15 @@ public class PlanetMapImpl implements PlanetMap {
         }
     }
 
+    //ajoute la valeur passée en paramètres à la case aux coordonnées spécifiées
+    public void setMapSquare(int x, int y, int value){
+        if(x==51) map[y+49][0] = value;
+        if(y==51) map[0][x+49] = value;
+        if(x==-50) map[y+49][99] = value;
+        if(y==-50) map[99][x+49] = value;
+        map[y+49][x+49] = value;
+    }
+
     //renvoie le contenu d'une case de la map
     //prendre en compte le cas où on demande une case en dehors du tableau
     //map circulaire, revenir de l'autre côté en transformant les coordonnées entrées

--- a/src/test/java/com/esiea/tp4A/domain/LaserBeamImplTest.java
+++ b/src/test/java/com/esiea/tp4A/domain/LaserBeamImplTest.java
@@ -1,0 +1,40 @@
+package com.esiea.tp4A.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class LaserBeamImplTest {
+
+    @Test
+    void ShootInitNORTH(){
+        MarsRoverImpl marsRover = new MarsRoverImpl(0,0, Direction.NORTH);
+        PlanetMapImpl planetMap = new PlanetMapImpl();
+        LaserBeamImpl laserBeam = marsRover.Shoot(planetMap);
+        Assertions.assertThat(laserBeam.getCurrentPosition()).isEqualTo(Position.of(marsRover.getCurrentPosition().getX(), marsRover.getCurrentPosition().getY()+1, Direction.NORTH));
+    }
+
+    @Test
+    void ShootInitSOUTH(){
+        MarsRoverImpl marsRover = new MarsRoverImpl(0,0, Direction.SOUTH);
+        PlanetMapImpl planetMap = new PlanetMapImpl();
+        LaserBeamImpl laserBeam = marsRover.Shoot(planetMap);
+        Assertions.assertThat(laserBeam.getCurrentPosition()).isEqualTo(Position.of(marsRover.getCurrentPosition().getX(), marsRover.getCurrentPosition().getY()-1, Direction.SOUTH));
+    }
+
+    @Test
+    void ShootInitWEST(){
+        MarsRoverImpl marsRover = new MarsRoverImpl(0,0, Direction.WEST);
+        PlanetMapImpl planetMap = new PlanetMapImpl();
+        LaserBeamImpl laserBeam = marsRover.Shoot(planetMap);
+        Assertions.assertThat(laserBeam.getCurrentPosition()).isEqualTo(Position.of(marsRover.getCurrentPosition().getX()-1, marsRover.getCurrentPosition().getY(), Direction.WEST));
+    }
+
+    @Test
+    void ShootInitEAST(){
+        MarsRoverImpl marsRover = new MarsRoverImpl(0,0, Direction.EAST);
+        PlanetMapImpl planetMap = new PlanetMapImpl();
+        LaserBeamImpl laserBeam = marsRover.Shoot(planetMap);
+        Assertions.assertThat(laserBeam.getCurrentPosition()).isEqualTo(Position.of(marsRover.getCurrentPosition().getX()+1, marsRover.getCurrentPosition().getY(), Direction.EAST));
+    }
+
+}


### PR DESCRIPTION
Création des classes LaserBeamImpl et LaserBeamImplTest.
Tests sur la position initiale du laser quand il est tiré par le rover en fonction de la direction de celui-ci.
Ajout d'une fonction move pour les lasers, fonction pour la détection d'une collision d'un laser avec un obstacle, auquel cas la case correspondante de la map où se trouvait l'obstacle redevient vide et égale à 0. Pour choisir la valeur d'une case de la map, ajout d'un setter qui prend en paramètre la valeur choisie et les coordonnées de la case.