### PR TITLE
ajout portée laser + tests

### DIFF
--- a/src/main/java/com/esiea/tp4A/domain/LaserBeamImpl.java
+++ b/src/main/java/com/esiea/tp4A/domain/LaserBeamImpl.java
@@ -5,27 +5,59 @@ public class LaserBeamImpl {
     private Position currentPosition;
     private Direction currentDirection;
     private boolean destroyed;
+    private int range;
+    private int distanceTravelled;
 
     LaserBeamImpl(int x, int y, Direction direction) {
         currentPosition = Position.of(x, y, direction);
         destroyed = false;
+        distanceTravelled=1;
+        range = initRange();
     }
 
     public Position getCurrentPosition(){
         return currentPosition;
     }
-
     public Boolean getDestroyed() { return destroyed; }
+    public int getRange() { return range; }
+
+    private int initRange(){
+        int alea = (int) (Math.random() * 10);
+        if(alea<6) { range = 30;} // faible portée
+        if(alea==10) { range = 10000;} //portée illimitée (réfléchir à un moyen de représenter l'infini de manière plus "propre")
+        else{ range = 60;} // portée moyenne
+        return range;
+    }
+
+
+    //ajoute la valeur passée en paramètres à la case aux coordonnées spécifiées
+    public void laserMapLimit(){
+        int x = getCurrentPosition().getX();
+        int y = getCurrentPosition().getY();
+        if(x==51) { this.currentPosition = Position.of(-48, y, currentDirection); System.out.println("x=51");
+            System.out.println("In laserMapLimit : Position map:" + this.getCurrentPosition().getX() + "," + this.getCurrentPosition().getY());
+        }
+        if(y==51) { this.currentPosition = Position.of(x, -48, currentDirection); System.out.println("y=51"); }
+        if(x==-50) { this.currentPosition = Position.of(48, y, currentDirection); System.out.println("x=-50"); }
+        if(y==-50) { this.currentPosition = Position.of(x, 48, currentDirection); System.out.println("y=-50"); }
+    }
 
     public Position move (PlanetMapImpl planetMap){
         currentDirection = currentPosition.getDirection();
         if(!destroyed){
+            //planetMap.MajMap(currentPosition.getX(), currentPosition.getY(), 0);
             if(currentDirection == Direction.SOUTH) currentPosition = Position.of(currentPosition.getX(), currentPosition.getY()-1, currentDirection);
             if(currentDirection == Direction.WEST) currentPosition = Position.of(currentPosition.getX()-1, currentPosition.getY(), currentDirection);
             if(currentDirection == Direction.NORTH) currentPosition = Position.of(currentPosition.getX(), currentPosition.getY()+1, currentDirection);
             if(currentDirection == Direction.EAST) currentPosition = Position.of(currentPosition.getX()+1, currentPosition.getY(), currentDirection);
+            distanceTravelled++;
+
+            System.out.println("Position map:" + this.getCurrentPosition().getX() + "," + this.getCurrentPosition().getY());
+            laserMapLimit();
         }
         obstacleCollisionCheck(planetMap);
+        rangeCheck();
+
         if(destroyed){ return null; }
         else{ return currentPosition;}
     }
@@ -34,6 +66,13 @@ public class LaserBeamImpl {
     public void obstacleCollisionCheck(PlanetMapImpl planetMap){
         if(planetMap.getInfo(currentPosition.getX(), currentPosition.getY())==1){
             planetMap.setMapSquare(currentPosition.getX(), currentPosition.getY(), 0);
+            destroyed = true;
+        }
+    }
+
+    //vérifier que le laser n'a pas atteint sa portée maximale
+    public void rangeCheck(){
+        if(distanceTravelled>range){
             destroyed = true;
         }
     }

--- a/src/test/java/com/esiea/tp4A/domain/LaserBeamImplTest.java
+++ b/src/test/java/com/esiea/tp4A/domain/LaserBeamImplTest.java
@@ -98,4 +98,32 @@ public class LaserBeamImplTest {
         Position position = laserBeam.getCurrentPosition();
         Assertions.assertThat(laserBeam.getDestroyed() && planetMap.getInfo(position.getX(), position.getY())==2); //Si je mets 1 à la fin ça marche toujours
     }
+
+    @Test
+    void initRangeTest(){
+        PlanetMapImpl planetMap = new PlanetMapImpl();
+        MarsRoverImpl marsRover = new MarsRoverImpl(0,0,Direction.SOUTH, planetMap);
+        LaserBeamImpl laserBeam = marsRover.Shoot(planetMap);
+        int range = laserBeam.getRange();
+        boolean initRange = false;
+        if(range == 30 || range == 60 || range == 10000){ initRange = true; }
+        Assertions.assertThat(initRange);
+    }
+
+    @Test
+    void rangeReached(){
+        PlanetMapImpl planetMap = new PlanetMapImpl();
+        MarsRoverImpl marsRover = new MarsRoverImpl(0,0,Direction.NORTH, planetMap);
+        LaserBeamImpl laserBeam = marsRover.Shoot(planetMap);
+        marsRover.move("R");
+        marsRover.move("F"); //on se décale pour ne pas se faire toucher par notre propre missile
+        int range = laserBeam.getRange();
+
+        //on se déplace jusqu'à la portée maximale du laser puis on vérifie qu'il a été détruit
+        for(int i=1 ; i<range ; i++){
+            //System.out.println("Position map:" + laserBeam.getCurrentPosition().getX() + "," + laserBeam.getCurrentPosition().getY());
+            laserBeam.move(planetMap);
+        }
+        Assertions.assertThat(laserBeam.getDestroyed());
+    }
 }


### PR DESCRIPTION
Ajout de l'attribut "portée du laser"
Modification du constructeur du laser
Fonction pour déterminer aléatoirement la portée du laser avec différentes probabilités pour chaque portée (faible, moyenne, infinie)
Fonction pour vérifier si un laser a atteint sa portée maximale, appel de cette fonction dans la fonction move du laser
Fonction pour faire en sorte que le laser retourne de l'autre côté de la map lorsqu'il en atteint une limite, quelques problèmes à résoudre concernant cette fonction (coordonnées/indices de la map)
Test pour vérifier l'initilasition de la portée du laser
Test pour vérifier sa destruction lorsqu'elle est atteinte