### PR TITLE
ajout test collision

### DIFF
--- a/src/test/java/com/esiea/tp4A/domain/MarsRoverImplTest.java
+++ b/src/test/java/com/esiea/tp4A/domain/MarsRoverImplTest.java
@@ -162,6 +162,20 @@ class MarsRoverImplTest {
     }
 
     @Test
+    void moves_are_ignored_in_case_of_collision(){
+        PlanetMapImpl planetMap = new PlanetMapImpl();
+        MarsRoverImpl marsRover = new MarsRoverImpl(0,0,Direction.SOUTH, planetMap);
+        //Placement des obstacles tout autour du Rover
+        planetMap.setMapSquare(0,1,1);
+        planetMap.setMapSquare(0,-1,1);
+        planetMap.setMapSquare(1,0,1);
+        planetMap.setMapSquare(-1,0,1);
+        Position expectedPos = Position.of(0,0,Direction.EAST);
+        Position position = marsRover.move("bllfrb");
+        Assertions.assertThat(marsRover.getCurrentPosition()).isEqualTo(expectedPos);
+    }
+
+    @Test
     void initPositionNextToObstacleNorth(){
         PlanetMapImpl planetMap = new PlanetMapImpl();
         MarsRoverImpl marsRover = new MarsRoverImpl(0,0,Direction.NORTH, planetMap);


### PR DESCRIPTION
Ajout d'un test pour la détection des obstacles
Les obstacles sont placés tout autour du Rover et celui ne doit donc pas pouvoir se déplacer, mais uniquement tourner sur lui-même lorsque l'on tente de le déplacer avec la chaîne de commande suivante : "bllfrb". Au début du test il est orienté vers le Sud et doit être tourné vers l'Est à l'issue du test.